### PR TITLE
Resolve preview conflict in watch app

### DIFF
--- a/WatchMQTT Watch App/ContentView.swift
+++ b/WatchMQTT Watch App/ContentView.swift
@@ -20,6 +20,10 @@ struct ContentView: View {
     }
 }
 
-#Preview {
-    ContentView()
+#if DEBUG
+struct ContentView_Previews: PreviewProvider {
+    static var previews: some View {
+        ContentView()
+    }
 }
+#endif


### PR DESCRIPTION
## Summary
- fallback to old-style preview provider in watch `ContentView`

## Testing
- `swiftc -parse "WatchMQTT Watch App/ContentView.swift"`

------
https://chatgpt.com/codex/tasks/task_e_684307413aec832aa1cdb99ac48af419