### PR TITLE
Improve watch connectivity and add test button

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,5 @@ Simple watch and phone apps for receiving MQTT messages over a WebSocket connect
 The watch no longer opens its own MQTT connection. Instead the phone app forwards any MQTT PUBLISH payloads it receives to the watch with `WatchConnectivity` so the watch can display them when both devices share the same Wi‑Fi network.
 
 The phone app still sends proper MQTT `CONNECT` and `SUBSCRIBE` packets after opening the WebSocket so brokers accept the connection. The WebSocket handshake includes `Sec-WebSocket-Protocol: mqtt`.
+
+Use the new **Send Test** button in the iOS app to verify that watch connectivity is working. The button sends a short message to the watch even if no MQTT data has been received.

--- a/WatchMQTT Watch App/Info.plist
+++ b/WatchMQTT Watch App/Info.plist
@@ -29,10 +29,6 @@
     <array>
         <string>remote-notification</string>
     </array>
-    <key>UIDeviceFamily</key>
-    <array>
-        <integer>4</integer>
-    </array>
     <key>WKCompanionAppBundleIdentifier</key>
     <string>MIA2.WatchMQTTApp</string>
     <key>WKRunsIndependentlyOfCompanionApp</key>

--- a/WatchMQTT Watch App/WatchConnectivityManager.swift
+++ b/WatchMQTT Watch App/WatchConnectivityManager.swift
@@ -1,3 +1,4 @@
+#if os(watchOS)
 import Foundation
 import WatchConnectivity
 
@@ -14,7 +15,13 @@ class WatchConnectivityManager: NSObject, ObservableObject, WCSessionDelegate {
         }
     }
 
-    func session(_ session: WCSession, activationDidCompleteWith activationState: WCSessionActivationState, error: Error?) {}
+    func session(_ session: WCSession,
+                 activationDidCompleteWith activationState: WCSessionActivationState,
+                 error: Error?) {
+        if activationState != .activated {
+            WCSession.default.activate()
+        }
+    }
     func sessionReachabilityDidChange(_ session: WCSession) {}
 
     func session(_ session: WCSession, didReceiveMessage message: [String : Any]) {
@@ -33,3 +40,4 @@ class WatchConnectivityManager: NSObject, ObservableObject, WCSessionDelegate {
         }
     }
 }
+#endif

--- a/WatchMQTTApp/ContentView.swift
+++ b/WatchMQTTApp/ContentView.swift
@@ -67,6 +67,15 @@ struct ContentView: View {
                             .cornerRadius(8)
                     }
                     Button(action: {
+                        self.debugMessages.append("Sending test message to watch")
+                        WatchConnectivityManager.shared.send(message: "Test from iPhone")
+                    }) {
+                        Text("Send Test")
+                            .padding()
+                            .background(Color.green.opacity(0.2))
+                            .cornerRadius(8)
+                    }
+                    Button(action: {
                         self.debugMessages = ["No messages yet"]
                     }) {
                         Text("Clear Debug")

--- a/WatchMQTTApp/WatchConnectivityManager.swift
+++ b/WatchMQTTApp/WatchConnectivityManager.swift
@@ -25,8 +25,12 @@ class WatchConnectivityManager: NSObject, WCSessionDelegate {
 
     // WCSessionDelegate stubs
     func session(_ session: WCSession, activationDidCompleteWith activationState: WCSessionActivationState, error: Error?) {}
+#if os(iOS)
+    // These callbacks are only available on iOS. Wrapping them ensures the file
+    // can be included in the watch target without build errors.
     func sessionDidBecomeInactive(_ session: WCSession) {}
     func sessionDidDeactivate(_ session: WCSession) {
         WCSession.default.activate()
     }
+#endif
 }


### PR DESCRIPTION
## Summary
- ensure the watch WCSession reactivates after deactivation
- provide a test button in iOS UI to send a message to the watch
- document the test button in README
- fix watch build errors by removing unavailable delegate methods and UIDeviceFamily key
- guard watch connectivity manager file so it only builds on watchOS

## Testing
- `git status --short`
- `swift --version`


------
https://chatgpt.com/codex/tasks/task_e_68432a850e30832a8b32dd39056e39d1